### PR TITLE
Added mod_frozen_nick

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 
   Sets a time limit to the conference.
 
-- [event_sync](event_sync/)
+- [event sync](event_sync/)
 
   Sends HTTP POST to external API when occupant or room events triggered.
+  
+- [frozen nick](frozen_nick/)
+
+  Prevents users from changing display name set by JWT auth.
+  
+
+  

--- a/frozen_nick/README.md
+++ b/frozen_nick/README.md
@@ -1,0 +1,37 @@
+# Frozen Nick
+
+This plugin stops users from changing display name if JWT auth is used and name is provided in token context.
+
+This is useful in a setup where user identity is established in another app and passed to Jitsi via JWT. Allowing users
+to change display name from a client app weakens the link between Jitsi user and in-app user identity. 
+
+
+## Installation
+
+- Copy this script to the Prosody plugins folder. It's the following folder on
+  Debian:
+
+  ```bash
+  cd /usr/share/jitsi-meet/prosody-plugins/
+  wget -O mod_frozen_nick.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/frozen_nick/mod_frozen_nick.lua
+  ```
+
+- Enable module in your prosody config.
+
+  _/etc/prosody/conf.d/meet.mydomain.com.cfg.lua_
+  
+  ```lua
+  VirtualHost "meet.mydomain.com"
+    modules_enabled = {
+      -- ... existing modules
+      "frozen_nick";
+    }
+  
+  ```
+  
+- Restart the services
+
+  ```bash
+  systemctl restart prosody.service
+  ```
+  

--- a/frozen_nick/mod_frozen_nick.lua
+++ b/frozen_nick/mod_frozen_nick.lua
@@ -1,0 +1,37 @@
+--- Stop users from changing nick (display name) if name is provided by jisi_meet_context_user
+
+
+-- For all received presence messages, if jitsi_meet_context_user.name value is set in the session, then we simply
+-- override nick with that value.
+function on_message(event)
+    if event and event["stanza"] then
+        if event.origin and event.origin.jitsi_meet_context_user then
+            local name = event.origin.jitsi_meet_context_user['name'];
+
+            if name then
+                -- first, drop existing 'nick' element
+                event.stanza:maptags(
+                    function(tag)
+                        for k, v in pairs(tag) do
+                            if k == "name" and v == "nick" then
+                                return nil;
+                            end
+                        end
+                        return tag
+                    end
+                )
+
+                -- then insert new one using name from user context
+                event.stanza:tag("nick", { xmlns = "http://jabber.org/protocol/nick"} ):text(name):up();
+
+                module:log("debug", "Nick replaced in stanza %s", tostring(event.stanza));
+            end
+        end
+    end
+end
+
+
+module:hook("pre-presence/bare", on_message);
+module:hook("pre-presence/full", on_message);
+
+module:log("info", "loaded mod_frozen_nick");


### PR DESCRIPTION
Plugin to stops users from changing display name if JWT auth is used and name is provided in token context.

Ref: https://community.jitsi.org/t/only-use-display-name-from-jwt/101016
