### PR TITLE
Option to include speaker stats in payload

### DIFF
--- a/event_sync/README.md
+++ b/event_sync/README.md
@@ -169,4 +169,7 @@ Component "event_sync.meet.mydomain.com" "event_sync_component"
     api_should_retry_for_code = function (code)
         return code >= 500 or code == 408
     end
+    
+    -- Optionally include total_dominant_speaker_time (milliseconds) in payload for occupant-left and room-destroyed
+    include_speaker_stats = true
 ```

--- a/event_sync/mod_event_sync_component.lua
+++ b/event_sync/mod_event_sync_component.lua
@@ -164,18 +164,6 @@ function EventData:on_occupant_leave(occupant_jid)
     return occupant_data;
 end
 
---- Returns array of occupant data for all active occupant.
---- @param exclude occupant_jid to exclude form the output
-function EventData:get_active_occupant_array(exclude)
-    local output = {};
-    for _, jid in ipairs(self.active) do
-        if jid ~= exclude then
-            table.insert(output, self.occupants[jid])
-        end
-    end
-
-    return output;
-end
 
 --- Returns array of all (past or present) occupants
 function EventData:get_occupant_array()


### PR DESCRIPTION
On occupant leave, we capture `totalDominantSpeakerTime` in cached payload of occupant and this gets returned for muc-occupant-leave and muc-room-destroyed events.

Closes https://github.com/jitsi-contrib/prosody-plugins/issues/9