### PR TITLE
added token_lobby_ondemand, simplified lobby_autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
   Enables some users to bypass lobby based on token content.
 
+- [token_lobby_ondemand](token_lobby_ondemand/)
+
+  Selectively send users to lobby based on token content. Enables lobby automatically if not yet activated.
+
 - [token owner party](token_owner_party/)
 
   Prevents the unauthorized users to create a room and terminates the conference

--- a/lobby_autostart/README.md
+++ b/lobby_autostart/README.md
@@ -16,6 +16,13 @@ the lobby with nobody to admit them.
   - Make sure you have a way for moderators to bypass the lobby  Test that it works when lobby is
     activated manually by another moderator.
   
+  - Check that you have `/usr/share/jitsi-meet/prosody-plugins/mod_persistent_lobby.lua`. If it's not there, that means
+    your version of Jitsi does not yet include [this PR](https://github.com/jitsi/jitsi-meet/pull/12215) which is required.
+    - If upgrading Jitsi is not an option for you, you can still use the
+      [older version of mod_lobby_autostart](https://github.com/jitsi-contrib/prosody-plugins/blob/ef33075897344bfb18e99bc7e56443bdb3027806/lobby_autostart/mod_lobby_autostart.lua)
+      which does not require mod_persistent_lobby.
+  
+
 - Copy this script to the Prosody plugins folder. It's the following folder on
   Debian 
 
@@ -24,12 +31,19 @@ the lobby with nobody to admit them.
    wget -O mod_lobby_autostart.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/lobby_autostart/mod_lobby_autostart.lua
    ```
   
-- Enable module in your prosody config.
+- Enable the module in your prosody config, as well as the 'persistent_lobby' module.
 
   _/etc/prosody/conf.d/meet.mydomain.com.cfg.lua_
 
   ```lua
-  VirtualHost "meet.mydomain.com"
+  Virtualhost "meet.mydomain.com"
+    modules_enabled = {
+      -- ...
+      "muc_lobby_rooms";
+      "persistent_lobby";
+    }
+  
+  Component "conference.meet.mydomain.com" "muc"
     modules_enabled = {
       -- ... existing modules
       "lobby_autostart";

--- a/lobby_autostart/mod_lobby_autostart.lua
+++ b/lobby_autostart/mod_lobby_autostart.lua
@@ -10,146 +10,15 @@
 
 local util = module:require "util";
 local is_healthcheck_room = util.is_healthcheck_room;
-local main_muc_component_host = module:get_option_string('main_muc');
-local lobby_muc_component_host = module:get_option_string('lobby_muc');
 
 
-if main_muc_component_host == nil then
-    module:log('error', 'main_muc not configured. Cannot proceed.');
-    return;
-end
+module:hook("muc-room-pre-create", function (event)
+   local room = event.room;
 
-if lobby_muc_component_host == nil then
-    module:log('error', 'lobby not enabled missing lobby_muc config');
-    return;
-end
-
-
--- Helper function to wait till a component is loaded before running the given callback
-function run_when_component_loaded(component_host_name, callback)
-    local function trigger_callback()
-        module:log('info', 'Component loaded %s', component_host_name);
-        callback(module:context(component_host_name), component_host_name);
+    if is_healthcheck_room(room.jid) then
+        return;
     end
 
-    if prosody.hosts[component_host_name] == nil then
-        module:log('debug', 'Host %s not yet loaded. Will trigger when it is loaded.', component_host_name);
-        prosody.events.add_handler('host-activated', function (host)
-            if host == component_host_name then
-                trigger_callback();
-            end
-        end);
-    else
-        trigger_callback();
-    end
-end
-
--- Helper function to wait till a component's muc module is loaded before running the given callback
-function run_when_muc_module_loaded(component_host_module, component_host_name, callback)
-    local function trigger_callback()
-        module:log('info', 'MUC module loaded for %s', component_host_name);
-        callback(prosody.hosts[component_host_name].modules.muc, component_host_module);
-    end
-
-    if prosody.hosts[component_host_name].modules.muc == nil then
-        module:log('debug', 'MUC module for %s not yet loaded. Will trigger when it is loaded.', component_host_name);
-        prosody.hosts[component_host_name].events.add_handler('module-loaded', function(event)
-            if (event.module == 'muc') then
-                trigger_callback();
-            end
-        end);
-    else
-        trigger_callback()
-    end
-end
-
-
-local lobby_muc_service;
-local main_muc_service;
-local main_muc_module;
-
-
--- Helper method to trigger main room destroy if room is persistent (no auto-delete) and destroy not yet triggered
-function trigger_room_destroy(room)
-    if room.get_persistent(room) and room._data.room_destroy_triggered == nil then
-        room._data.room_destroy_triggered = true;
-        main_muc_module:fire_event("muc-room-destroyed", { room = room; });
-    end
-end
-
-
--- Handle events on main muc module
-run_when_component_loaded(main_muc_component_host, function(host_module, host_name)
-    run_when_muc_module_loaded(host_module, host_name, function (main_muc, main_module)
-        main_muc_service = main_muc;  -- so it can be accessed from lobby muc event handlers
-        main_muc_module = main_module;
-
-        main_module:hook("muc-room-pre-create", function (event)
-            local main_room = event.room;
-
-            if is_healthcheck_room(main_room.jid) then
-                return;
-            end
-
-            -- Activate lobby
-            prosody.events.fire_event("create-lobby-room", { room = main_room; });
-
-            -- we also need to disable the empty-room-deletion feature for the main room since initial users could be
-            -- waiting in the lobby before anybody joins the room, and empty rooms will get deleted after a period
-            -- and users still in lobby end up in an error state.
-            main_room:set_persistent(true);
-
-        end);
-
-        -- N.B. Since we main room and lobby room are now persistent, we need to trigger deletion ourselves when both
-        -- the main room and the lobby room is empty. This will be checked each time an occupant leaves the main room
-        -- of if someone drops off the lobby.
-
-        main_module:hook("muc-occupant-left", function(event)
-            -- Check if room should be destroyed when someone leaves the main room
-
-            local main_room = event.room;
-            local lobby_room_jid = main_room._data.lobbyroom;
-
-            -- If occupant leaving results in main room being empty, we trigger room destroy if
-            --   a) lobby exists and is not empty
-            --   b) lobby does not exist (possible for lobby to be disabled manually by moderator in meeting)
-            --
-            -- (main room destroy also triggers lobby room destroy in muc_lobby_rooms)
-            if not main_room:has_occupant() then
-                if lobby_room_jid == nil then  -- lobby disabled
-                    trigger_room_destroy(main_room);
-                else -- lobby exists
-                    local lobby_room = lobby_muc_service.get_room_from_jid(lobby_room_jid);
-                    if lobby_room and not lobby_room:has_occupant() then
-                        trigger_room_destroy(main_room);
-                    end
-                end
-            end
-        end);
-
-    end);
-end);
-
-
--- Handle events on lobby muc module
-run_when_component_loaded(lobby_muc_component_host, function(host_module, host_name)
-    run_when_muc_module_loaded(host_module, host_name, function (lobby_muc, lobby_module)
-        lobby_muc_service = lobby_muc;  -- so it can be accessed from main muc event handlers
-
-        lobby_module:hook("muc-occupant-left", function(event)
-            -- Check if room should be destroyed when someone leaves the lobby
-
-            local lobby_room = event.room;
-            local main_room = lobby_room.main_room;
-
-            -- If both lobby room and main room are empty, we destroy main room.
-            -- (main room destroy also triggers lobby room destroy in muc_lobby_rooms)
-            if not lobby_room:has_occupant() and main_room and not main_room:has_occupant() then
-                trigger_room_destroy(main_room);
-            end
-
-        end);
-    end);
+    prosody.events.fire_event("create-lobby-room", { room = room; });
 end);
 

--- a/token_lobby_ondemand/README.md
+++ b/token_lobby_ondemand/README.md
@@ -1,0 +1,84 @@
+# Token Lobby On-Demand
+
+This plugin dynamically enables lobby when a user joins with `"lobby": true` in token. Token users without 
+`"lobby": true` will be excluded from the lobby.
+
+## How is this different from lobby_autostart?
+
+With [lobby_autostart](../lobby_autostart/), all rooms will automatically have lobby activated on creation, and 
+you need something like [token_lobby_bypass](../token_lobby_bypass/) to opt users out of lobby.
+
+This module is the opposite; you use a field in the token to opt users into using lobby, and lobby is only activated
+when it is required.
+
+
+## Installation
+- Prerequisites:
+  - Enable the lobby feature and test that it works as expected when manually activated by a moderator.
+
+  - Set up [JWT auth](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md) and check that it works before 
+  proceeding.
+  
+  - Check that you have `/usr/share/jitsi-meet/prosody-plugins/mod_persistent_lobby.lua`. If it's not there, that means
+    your version of Jitsi does not yet include [this PR](https://github.com/jitsi/jitsi-meet/pull/12215) which is required.
+
+
+- Copy this script to the Prosody plugins folder. It's the following folder on
+  Debian:
+
+  ```bash
+  cd /usr/share/jitsi-meet/prosody-plugins/
+  wget -O mod_token_lobby_ondemand.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/token_lobby_ondemand/mod_token_lobby_ondemand.lua
+  ```
+
+- Enable the module in your prosody config, as well as the 'persistent_lobby' module.
+
+  _/etc/prosody/conf.d/meet.mydomain.com.cfg.lua_
+
+  ```lua
+  Virtualhost "meet.mydomain.com"
+    modules_enabled = {
+      -- ...
+      "muc_lobby_rooms";
+      "persistent_lobby";
+    }
+  
+  Component "conference.meet.mydomain.com" "muc"
+    modules_enabled = {
+      -- ... existing modules
+      "token_lobby_bypass";
+    }
+  ```
+
+- Restart the services
+
+  ```bash
+  systemctl restart prosody.service
+  ```
+
+## A token sample
+
+To send a user to the lobby (and activate lobby if it is not yet activated), set the `lobby` attribute to 
+boolean `true` in `context.features`.
+
+A sample token body:
+
+```json
+{
+  "room": "myRoomName",
+  "context": {
+    "user": {
+      "name": "myname",
+      "email": "myname@mydomain.com",
+    },
+    "features": {
+      "lobby": true
+    }
+  },
+  "aud": "myapp",
+  "iss": "myapp",
+  "sub": "meet.mydomain.com",
+  "iat": 1601366000,
+  "exp": 1601366180
+}
+```

--- a/token_lobby_ondemand/mod_token_lobby_ondemand.lua
+++ b/token_lobby_ondemand/mod_token_lobby_ondemand.lua
@@ -1,0 +1,52 @@
+--- Plugin to dynamically enable lobby when required by token, and exclude those without the attribute
+---
+--- This module should be added to the main muc component.
+---
+
+local LOGLEVEL = "debug";
+
+local muc_util = module:require "muc/util";
+local valid_affiliations = muc_util.valid_affiliations;
+local is_healthcheck_room = module:require "util".is_healthcheck_room;
+
+
+module:hook("muc-occupant-pre-join", function (event)
+    local room, occupant = event.room, event.occupant;
+
+    if is_healthcheck_room(room.jid) then
+        return;
+    end
+
+    if not event.origin.auth_token then
+        module:log(LOGLEVEL, "skip user with no token - %s", occupant.bare_jid)
+        return
+    end
+
+    local context = event.origin.jitsi_meet_context_features;
+    local user_should_use_lobby = (context ~= nil and context["lobby"] == true);
+    local lobby_enabled = (room._data.lobbyroom ~= nil);
+
+    if lobby_enabled then
+        -- If lobby already enabled, exclude user from lobby if necessary
+        if not user_should_use_lobby then
+            module:log(DEBUG, "Bypassing lobby for room %s occupant %s", room.jid, occupant.bare_jid);
+
+            occupant.role = 'participant';
+
+            -- set affiliation to "member" if not yet assigned by other plugins
+            local affiliation = room:get_affiliation(occupant.bare_jid);
+            if valid_affiliations[affiliation or "none"] < valid_affiliations.member then
+                module:log(DEBUG, "Setting affiliation for %s -> member", occupant.bare_jid);
+                room:set_affiliation(true, occupant.bare_jid, 'member');
+            end
+        end
+    else
+        if user_should_use_lobby then
+            -- if lobby not yet enabled and user should be subject to it, so we enable it
+            prosody.events.fire_event("create-persistent-lobby-room", { room = room; });
+        end
+    end
+
+end, -3);
+--- Run just before lobby(priority -4) and members_only (-5).
+--- Must run after token_verification (99), max_occupants (10), allowners (2).


### PR DESCRIPTION
This change depends on https://github.com/jitsi/jitsi-meet/pull/12215.

The bulk of the logic from lobby_autostart has been ported to mod_persistent_lobby; what remains is now rather trivial.

mod_persistent_lobby also opens up the door for token_lobby_ondemand which in theory is more efficient in large deployments since we don't pre-start lobby on all rooms but only activate it when required.