### PR TITLE
token_lobby_bypass, token_lobby_ondemand: use user context 

### DIFF
--- a/token_lobby_bypass/README.md
+++ b/token_lobby_bypass/README.md
@@ -36,7 +36,7 @@ This plugin allows you to let some users bypass the lobby by setting a flag in t
 
 ## A token sample
 
-To allow a user to bypass the lobby, set the `lobby_bypass` attribute to boolean `true` in `context.features`.
+To allow a user to bypass the lobby, set the `lobby_bypass` attribute to boolean `true` in `context.user`.
 
 A sample token body:
 
@@ -47,8 +47,6 @@ A sample token body:
     "user": {
       "name": "myname",
       "email": "myname@mydomain.com",
-    },
-    "features": {
       "lobby_bypass": true
     }
   },

--- a/token_lobby_bypass/mod_token_lobby_bypass.lua
+++ b/token_lobby_bypass/mod_token_lobby_bypass.lua
@@ -28,7 +28,7 @@ module:hook("muc-occupant-pre-join", function (event)
         return
     end
 
-    local context = event.origin.jitsi_meet_context_features;
+    local context = event.origin.jitsi_meet_context_user;
 
     if context then
         if context['lobby_bypass'] == true then

--- a/token_lobby_ondemand/README.md
+++ b/token_lobby_ondemand/README.md
@@ -59,7 +59,7 @@ when it is required.
 ## A token sample
 
 To send a user to the lobby (and activate lobby if it is not yet activated), set the `lobby` attribute to 
-boolean `true` in `context.features`.
+boolean `true` in `context.user`.
 
 A sample token body:
 
@@ -70,8 +70,6 @@ A sample token body:
     "user": {
       "name": "myname",
       "email": "myname@mydomain.com",
-    },
-    "features": {
       "lobby": true
     }
   },

--- a/token_lobby_ondemand/mod_token_lobby_ondemand.lua
+++ b/token_lobby_ondemand/mod_token_lobby_ondemand.lua
@@ -22,7 +22,7 @@ module:hook("muc-occupant-pre-join", function (event)
         return
     end
 
-    local context = event.origin.jitsi_meet_context_features;
+    local context = event.origin.jitsi_meet_context_user;
     local user_should_use_lobby = (context ~= nil and context["lobby"] == true);
     local lobby_enabled = (room._data.lobbyroom ~= nil);
 


### PR DESCRIPTION
Switch to using `context.user.*` for custom plugins 

`context.features.lobby` might conflict with `isJwtFeatureEnabled(..., 'lobby', ...)` in Jitsi Meet. Use of `context.features.*` would also raise _“- Invalid feature: *”_ error in dev console if not recognised by Jitsi Meet.

