### PR TITLE
token_no_wildcard: new plugin to reject tokens that use wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 
   Sets the occupant's affiliation according to the token content.
 
+- [token no wildcard](token_no_wildcard/)
+
+  Enforces single room per token by rejecting tokens that use wildcards or regex-based room names.
+
 - [token lobby bypass](token_lobby_bypass/)
 
   Enables some users to bypass lobby based on token content.

--- a/token_no_wildcard/README.md
+++ b/token_no_wildcard/README.md
@@ -1,0 +1,40 @@
+# Token No Wildcard
+
+This plugin pre-validates tokens and rejects any token that uses wildcards (`'*'`) for `room` or `sub` claim, or if
+regex-based matching is requested.
+
+In effect, it insists that all tokens can only be used for one specific room thus reducing the blast radius should
+someone accidentally share their token.
+
+
+## Installation
+- Prerequisites:
+
+  - Set up [JWT auth](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md) and check that it works before 
+  proceeding.
+
+- Copy this script to the Prosody plugins folder. It's the following folder on
+  Debian:
+
+  ```bash
+  cd /usr/share/jitsi-meet/prosody-plugins/
+  wget -O mod_token_no_wildcard.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/token_no_wildcard/mod_token_no_wildcard.lua
+  ```
+
+- Enable the module in your prosody config
+
+  _/etc/prosody/conf.d/meet.mydomain.com.cfg.lua_
+
+  ```lua
+  Component "conference.meet.mydomain.com" "muc"
+    modules_enabled = {
+      -- ... existing modules
+      "token_no_wildcard";
+    }
+  ```
+
+- Restart the services
+
+  ```bash
+  systemctl restart prosody.service
+  ```

--- a/token_no_wildcard/mod_token_no_wildcard.lua
+++ b/token_no_wildcard/mod_token_no_wildcard.lua
@@ -1,0 +1,69 @@
+--- Plugin to deny access to tokens that use wildcards or regex matches.
+--- This limits the scope of all tokens to only the explicitly named room and subdomain.
+---
+--- To install, add module to main conference muc component.
+---
+
+local LOGLEVEL = "info";
+
+local st = require "util.stanza";
+local um_is_admin = require "core.usermanager".is_admin;
+
+
+local function is_admin(jid)
+    return um_is_admin(jid, module.host);
+end
+
+
+local function verify_no_wildcard_in_token(session, stanza)
+    local user_jid = stanza.attr.from;
+
+    -- token not required for admin user.
+    if is_admin(user_jid) then
+        return true;
+    end
+
+    -- Reject if wildcard in room claim
+    if session.jitsi_meet_room == '*' then
+        module:log(LOGLEVEL, "Reject %s -- wildcard in room claim", user_jid);
+        session.send(
+            st.error_reply(
+                stanza, "cancel", "not-allowed", "Wildcard room in token not allowed"));
+        return false;
+    end
+
+    -- Reject if wildcard in sub claim
+    if session.jitsi_meet_domain == '*' then
+        module:log(LOGLEVEL, "Reject %s -- wildcard in sub claim", user_jid);
+        session.send(
+            st.error_reply(
+                stanza, "cancel", "not-allowed", "Wildcard sub in token not allowed"));
+        return false;
+    end
+
+    -- Reject regex matching of room name
+    local room_context = session.jitsi_meet_context_room;
+    if room_context and (room_context["regex"] == true or room_context["regex"] == "true") then
+        module:log(LOGLEVEL, "Reject %s -- regex match requested in token", user_jid);
+        session.send(
+            st.error_reply(
+                stanza, "cancel", "not-allowed", "Regex support not allowed for token"));
+        return false;
+    end
+
+    return true;
+end
+
+module:hook("muc-room-pre-create", function(event)
+    local origin, stanza = event.origin, event.stanza;
+    if not verify_no_wildcard_in_token(origin, stanza) then
+        return true; -- Returning any value other than nil will halt processing of the event
+    end
+end, 100);  --- run before mod_token_verification (99)
+
+module:hook("muc-occupant-pre-join", function(event)
+    local origin, room, stanza = event.origin, event.room, event.stanza;
+    if not verify_no_wildcard_in_token(origin, stanza) then
+        return true; -- Returning any value other than nil will halt processing of the event
+    end
+end, 100); --- run before mod_token_verification (99)


### PR DESCRIPTION
In effect, this plugin insists that all tokens can only be used for one specific room thus reducing the blast radius should
someone accidentally share their token. 

Runs before mod_token_verification and reject if sub/room is set to `'*'` or if `context.room.regex = true`.