### PR TITLE
event_sync, fix: the problem of sending events for breakout rooms has been resolved

### DIFF
--- a/event_sync/mod_event_sync_component.lua
+++ b/event_sync/mod_event_sync_component.lua
@@ -372,6 +372,7 @@ function run_when_muc_module_loaded(component_host_module, component_host_name, 
     end
 end
 
+local main_muc_service; -- luacheck: ignore
 
 -- No easy way to infer main room from breakout room object, so search all rooms in main muc component and cache
 -- it on room so we don't have to search again
@@ -406,7 +407,6 @@ function handle_main_room_created(event)
     room:save();
 end
 
-local main_muc_service; -- luacheck: ignore
 
 -- Predefine breakout room attributes to be included in API payload for all events
 -- This should be scheduled AFTER speakerStats module, but BEFORE handler that compiles and sends API payload


### PR DESCRIPTION
The problem of sending events for breakout rooms has been resolved.

Forum topic regarding the problem;
[Prosody “event_sync plugin” for breakout rooms don’t send any event](https://community.jitsi.org/t/prosody-event-sync-plugin-for-breakout-rooms-dont-send-any-event/130193)