### PR TITLE
event_sync, feat: add number of active occupants to join/left events

### DIFF
--- a/event_sync/README.md
+++ b/event_sync/README.md
@@ -72,6 +72,7 @@ When an occupant joins, `POST ${api_prefix}/events/occupant/joined` is called wi
 * room_jid
 * is_breakout
 * breakout_room_id (only if is_breakout is true)
+* active_occupants_count (current number of active occupants, including the one that just joined)
 * occupant
     * occupant_jid
     * joined_at
@@ -87,6 +88,7 @@ Example:
   "room_name": "catchup",
   "room_jid": "catchup@conference.meet.mydomain.com",
   "is_breakout": false,
+  "active_occupants_count": 4,
   "occupant": {
     "name": "James Barrow",
     "email": "j.barrow@domain.com",
@@ -105,6 +107,7 @@ When an occupant leaves, `POST ${api_prefix}/events/occupant/left` is called wit
 * room_jid
 * is_breakout
 * breakout_room_id (only if is_breakout is true)
+* active_occupants_count (current number of active occupants, excluding the one that just left)
 * occupant
     * occupant_jid
     * joined_at
@@ -121,6 +124,7 @@ Example:
   "room_name": "catchup",
   "room_jid": "catchup@conference.meet.mydomain.com",
   "is_breakout": false,
+  "active_occupants_count": 3,
   "occupant": {
     "name": "James Barrow",
     "email": "j.barrow@domain.com",

--- a/event_sync/mod_event_sync_component.lua
+++ b/event_sync/mod_event_sync_component.lua
@@ -187,6 +187,16 @@ function EventData:get_occupant_array()
     return output;
 end
 
+--- Returns number of active occupants
+function EventData:get_active_occupants_count()
+    local output = 0;
+    for _ in pairs(self.active) do
+        output = output + 1
+    end
+
+    return output;
+end
+
 --- End EventData implementation
 
 
@@ -291,6 +301,7 @@ function occupant_joined(event)
     local payload = {
             ['event_name'] = 'muc-occupant-joined';
             ['occupant'] = occupant_data;
+            ['active_occupants_count'] = room_data:get_active_occupants_count();
     };
     update_with_room_attributes(payload, room);
 
@@ -323,6 +334,7 @@ function occupant_left(event)
     local payload = {
             ['event_name'] = 'muc-occupant-left';
             ['occupant'] = occupant_data;
+            ['active_occupants_count'] = room_data:get_active_occupants_count();
     };
     update_with_room_attributes(payload, room);
 


### PR DESCRIPTION
Active occupants are already tracked in implementation; this adds the tally to join/left events, allowing to avoid similar tracking on the API consumer side.