### PR TITLE
jibri_autostart: handle occupant leaving soon after join

### DIFF
--- a/jibri_autostart/mod_jibri_autostart.lua
+++ b/jibri_autostart/mod_jibri_autostart.lua
@@ -23,7 +23,7 @@ local function _start_recording(room, session, occupant_jid)
     local occupant = room:get_occupant_by_real_jid(occupant_jid)
 
     -- check recording permission
-    if occupant.role ~= "moderator" then
+    if occupant == nil or occupant.role ~= "moderator" then
         return
     elseif
         session.jitsi_meet_context_features ~= nil and


### PR DESCRIPTION
The jid from event is only used to lookup occupant data 3 seconds after joining. If user leaves during that window, `nil` is returned from occupant lookup and we see error as posted [here](https://github.com/jitsi/jitsi-meet/issues/15335#issuecomment-2500027565).