### PR TITLE
Add plugin mod_lobby_autostart_on_owner

### DIFF
--- a/lobby_autostart_on_owner/README.md
+++ b/lobby_autostart_on_owner/README.md
@@ -1,0 +1,57 @@
+# Lobby Autostart (on owner)
+
+This plugin automatically manages lobby activation and moderator assignment:
+
+- **When a new owner (moderator) joins**, it automatically enables the lobby for the room if not already active.
+- **When the last owner leaves**, it automatically promotes one of the remaining participants (`member`) to `owner` to ensure someone can admit users from the lobby.
+
+## Known Issues
+
+- When authorization is required to create a room (e.g., JWT authentication is enabled), participants who were waiting before the moderator joined may enter the room directly without passing through the lobby.
+  This happens because the lobby is activated shortly *after* the moderator joins.
+
+## Installation
+- **Installing the plugin:**
+
+  ```bash
+  cd /usr/share/jitsi-meet/prosody-plugins/
+  wget -O mod_lobby_autostart_on_owner.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
+  ```
+
+- **Configuring Prosody:**
+
+  Edit your `/etc/prosody/conf.d/meet.mydomain.com.cfg.lua`:
+
+  ```lua
+  Component "conference.meet.mydomain.com" "muc"
+    modules_enabled = {
+      -- ... existing modules
+      "lobby_autostart_on_owner";
+    }
+  ```
+
+- **Restart Prosody:**
+
+  ```bash
+  systemctl restart prosody.service
+  ```
+
+## Installation in Docker
+- **Installing the plugin:**
+  ```bash
+  cd ${CONFIG}/prosody/prosody-plugins/custom
+  wget -O mod_lobby_autostart_on_owner.lua https://raw.githubusercontent.com/jitsi-contrib/prosody-plugins/main/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
+  ```
+
+- **Edit your `.env` file:**
+
+  ```
+  XMPP_MUC_MODULES=...,lobby_autostart_on_owner
+  ```
+
+- **Restart the containers:**
+
+  ```bash
+  docker-compose down
+  docker-compose up -d
+  ```

--- a/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
+++ b/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
@@ -1,0 +1,84 @@
+-- This module auto-activates lobby for all rooms.
+--
+-- This module should be added to the main muc component.
+--
+
+local jid_split = require 'util.jid'.split;
+
+module:hook("muc-set-affiliation", function(event)
+    local room = event.room;
+    local jid = event.jid;
+    local affiliation = event.affiliation;
+
+    if not room then
+        module:log("warn", "No room in muc-set-affiliation event");
+        return;
+    end
+
+    local username = jid_split(jid);
+
+    if username == "focus" then
+        return;
+    end
+
+    if affiliation ~= "owner" then
+        return;
+    end
+
+    if room._data.lobbyroom then
+        module:log("debug", "Lobby already exists for %s", room.jid);
+        return;
+    end
+
+    module:log("info", "Creating lobby for %s because %s became owner", room.jid, jid);
+    prosody.events.fire_event('create-lobby-room', { room = room });
+end);
+
+module:hook("muc-occupant-left", function(event)
+    local room = event.room;
+    local occupant = event.occupant;
+
+    if not room or not occupant then
+        module:log("warn", "No room or occupant in muc-occupant-left event");
+        return;
+    end
+
+    local occupant_jid = occupant.bare_jid;
+    local aff = room:get_affiliation(occupant_jid);
+
+    module:log("debug", "Occupant %s left, affiliation was %s", occupant_jid, tostring(aff));
+
+    if aff ~= "owner" then
+        module:log("debug", "Left occupant was not owner, ignoring");
+        return;
+    end
+
+    local has_owner = false;
+    for jid, affiliation in room:each_affiliation() do
+        if affiliation == "owner" then
+            local occupant = room:get_occupant_by_real_jid(jid);
+            if occupant then
+                module:log("debug", "Still alive owner found: %s", jid);
+                has_owner = true;
+                break;
+            else
+                module:log("debug", "Dead owner affiliation found: %s (not in room)", jid);
+            end
+        end
+    end
+
+    if has_owner then
+        module:log("debug", "Room %s still has live owners, nothing to do", room.jid);
+        return;
+    end
+
+    module:log("info", "No more owners in room %s, trying to assign a new one", room.jid);
+
+    for _, occupant in room:each_occupant() do
+        if occupant.role == "participant" then
+            module:log("info", "Assigning new owner: %s", occupant.bare_jid);
+            room:set_affiliation(true, occupant.bare_jid, "owner");
+            break;
+        end
+    end
+end);

--- a/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
+++ b/lobby_autostart_on_owner/mod_lobby_autostart_on_owner.lua
@@ -17,11 +17,7 @@ module:hook("muc-set-affiliation", function(event)
 
     local username = jid_split(jid);
 
-    if username == "focus" then
-        return;
-    end
-
-    if affiliation ~= "owner" then
+    if username == "focus" or affiliation ~= "owner" then
         return;
     end
 
@@ -56,8 +52,8 @@ module:hook("muc-occupant-left", function(event)
     local has_owner = false;
     for jid, affiliation in room:each_affiliation() do
         if affiliation == "owner" then
-            local occupant = room:get_occupant_by_real_jid(jid);
-            if occupant then
+            local real_occupant = room:get_occupant_by_real_jid(jid);
+            if real_occupant then
                 module:log("debug", "Still alive owner found: %s", jid);
                 has_owner = true;
                 break;
@@ -74,10 +70,10 @@ module:hook("muc-occupant-left", function(event)
 
     module:log("info", "No more owners in room %s, trying to assign a new one", room.jid);
 
-    for _, occupant in room:each_occupant() do
-        if occupant.role == "participant" then
-            module:log("info", "Assigning new owner: %s", occupant.bare_jid);
-            room:set_affiliation(true, occupant.bare_jid, "owner");
+    for _, current_occupant in room:each_occupant() do
+        if current_occupant.role == "participant" then
+            module:log("info", "Assigning new owner: %s", current_occupant.bare_jid);
+            room:set_affiliation(true, current_occupant.bare_jid, "owner");
             break;
         end
     end


### PR DESCRIPTION
This plugin automatically creates a lobby when the first moderator joins a room.
It does not require any additional tokens or lobby bypass mechanisms.
If all moderators leave the room, it automatically promotes a random participant to moderator, ensuring there is always someone who can admit new users.