### PR TITLE
feat(auth_hybrid_matrix_token): add a prosody var to disable room membership verification

### DIFF
--- a/auth_hybrid_matrix_token/README.md
+++ b/auth_hybrid_matrix_token/README.md
@@ -37,6 +37,13 @@ token and handles it depending on its type.
     -- (optional) UVS auth token, if authentication enabled on UVS.
     -- Uncomment and set the right token if necessary.
     --uvs_auth_token = "changeme"
+
+    -- (optional) Disable room membership verification. When set to true, the 
+    -- module will only check whether the user exists on the Matrix server, 
+    -- without verifying their membership in the room. This is useful if you 
+    -- don’t want to generate a Synapse token for the UVS, as it becomes 
+    -- unnecessary in this case. Defaults to false.
+    -- uvs_disable_membership_verification = true
     }
   ```
 


### PR DESCRIPTION
Currently, the module always calls the `/verify/user_in_room` endpoint of UVS, which requires a Synapse admin user token to work, and will only work on Synapse. 
This PR adds a Prosody config option that disables room membership verification, and only checks if the user exists. 